### PR TITLE
Fixed table overflow on server outage

### DIFF
--- a/components/KpiTable.tsx
+++ b/components/KpiTable.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router"
 import useSWR from "swr"
 import {
+  ApiError,
   getKpiForProjectRoute,
   getKpisForProjectApiRoute,
   Kpi,
@@ -25,7 +26,7 @@ export default function KpiTable(props: Props) {
     sortInformation,
     setSortInformation,
   } = usePagination("name")
-  const { data: kpis, error: error } = useSWR<Kpi[]>(
+  const { data: kpis, error: error } = useSWR<Kpi[], ApiError>(
     getKpisForProjectApiRoute(
       projectID,
       pageSize,
@@ -34,7 +35,7 @@ export default function KpiTable(props: Props) {
       sortInformation.ordering,
     ),
   )
-  if (error) {
+  if (error && error.statusCode == 404) {
     setPageNumber(pageNumber - 1)
   }
 

--- a/lib/api/fetchJson.ts
+++ b/lib/api/fetchJson.ts
@@ -1,3 +1,5 @@
+import { ApiError } from "."
+
 export async function fetchJson(
   input: RequestInfo,
   init?: RequestInit | undefined,
@@ -12,7 +14,6 @@ export async function fetchJson(
     return data
   }
 
-  const error = new Error(response.statusText)
-  error.stack = data
+  const error = new ApiError(response.status, response.statusText)
   throw error
 }

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -48,3 +48,12 @@ export type Pagination = {
   pageSize: number
   pageNumber: number
 }
+
+export class ApiError extends Error {
+  statusCode: number
+
+  constructor(statusCode: number, message?: string) {
+    super(message)
+    this.statusCode = statusCode
+  }
+}

--- a/pages/analytics/index.tsx
+++ b/pages/analytics/index.tsx
@@ -9,6 +9,7 @@ import { Page } from "../../components/layout"
 import Rating from "../../components/rating/Rating"
 import Table from "../../components/table/Table"
 import {
+  ApiError,
   AuthorizationDetails,
   getAnalyticsForProjectRoute,
   getProjectsApiRoute,
@@ -28,7 +29,7 @@ const Analytics: NextPage = requireAuthorization(
       sortInformation,
       setSortInformation,
     } = usePagination("name")
-    const { data: projects, error: error } = useSWR<Project[]>(
+    const { data: projects, error: error } = useSWR<Project[], ApiError>(
       getProjectsApiRoute(
         pageSize,
         pageNumber,
@@ -36,7 +37,7 @@ const Analytics: NextPage = requireAuthorization(
         sortInformation.ordering,
       ),
     )
-    if (error) {
+    if (error && error.statusCode == 404) {
       setPageNumber(pageNumber - 1)
     }
     return (


### PR DESCRIPTION
I fixed the bug described in #42 

Given that [MDN describes the stack property of the Error class to be non-standard and not to be used in production](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) (and since the call trace is not the server's error response), I added a new `ApiError` class that also stores the HTTP status code. Which makes it easier for the components to find out what error occurred.

We should also think of a uniform error scheme for the API to use in case of errors. Instead of using the status text as message.